### PR TITLE
Fixed exception copying while catching

### DIFF
--- a/Source/Actor.cpp
+++ b/Source/Actor.cpp
@@ -274,7 +274,7 @@ void Actor::load(const std::string& filename)
 		load(bytes, (unsigned int)length);
 		delete [] bytes;
 	}
-	catch (OverflowException ex)
+	catch (const OverflowException &ex)
 	{
 		delete [] bytes;
 		throw ex;


### PR DESCRIPTION
Xcode 10.3 fails to build due to exception being catched by value:
```

/Applications/Xcode.app/Contents/Developer/usr/bin/make dirs libnima.a headers
clang++ -Wall -Werror -g -std=c++11 -I./ -INima-Math-Cpp/Build/include   -c Source/Actor.cpp -o Build/obj/Source/Actor.o
Source/Actor.cpp:280:9: error: local variable 'ex' will be copied despite being
      thrown by name [-Werror,-Wreturn-std-move]
                throw ex;
                      ^~
Source/Actor.cpp:280:9: note: call 'std::move' explicitly to avoid copying
                throw ex;
                      ^~
                      std::move(ex)
1 error generated.
```